### PR TITLE
fix uint18array append bug

### DIFF
--- a/src/common/clip.js
+++ b/src/common/clip.js
@@ -43,7 +43,10 @@ var Clip = {
 
     // WARNING: Leaves samples out of date.
     addSpeex: function(clip, data) {
-        Array.prototype.push.apply(clip.speex, data);
+        var tmp = new Uint8Array(clip.speex.byteLength + data.byteLength); 
+    	tmp.set(new Uint8Array(clip.sppex), 0); 
+    	tmp.set(new Uint8Array(data), clip.speex.byteLength); 
+    	clip.speex = tmp;
     },
 
     // WARNING: Potentially slow.

--- a/src/common/clip.js
+++ b/src/common/clip.js
@@ -44,7 +44,7 @@ var Clip = {
     // WARNING: Leaves samples out of date.
     addSpeex: function(clip, data) {
         var tmp = new Uint8Array(clip.speex.byteLength + data.byteLength); 
-    	tmp.set(new Uint8Array(clip.sppex), 0); 
+    	tmp.set(new Uint8Array(clip.speex), 0); 
     	tmp.set(new Uint8Array(data), clip.speex.byteLength); 
     	clip.speex = tmp;
     },


### PR DESCRIPTION
I do not know am I alone with this error or anybody else has met it, but when I start recording audio in chrome the next error notification appears:
cannot set property length of #uint18array which has only a getter
